### PR TITLE
Update iOS header import for RN 0.40

### DIFF
--- a/ios/KCKeepAwake.h
+++ b/ios/KCKeepAwake.h
@@ -1,4 +1,4 @@
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface KCKeepAwake : NSObject <RCTBridgeModule>
 @end


### PR DESCRIPTION
As you can see from [RN 0.40 release notes](https://github.com/facebook/react-native/releases/tag/v0.40.0) they have moved ALL native modules on iOS. All packages that use `.h`-files starting with `RCT` they have to be refactored to the new path.

So basically `react-native-keep-awake` won't work with RN 0.40 without this PR! :)