### PR TITLE
Fix bug where screen does not stay on when coming back from background [Android]

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,21 +4,12 @@ import React, { Component } from 'react';
 import { NativeModules } from 'react-native';
 
 export default class KeepAwake extends Component {
-
-  static isActive = false;
-
   static activate() {
-      if (!KeepAwake.isActive) {
-          NativeModules.KCKeepAwake.activate();
-          KeepAwake.isActive = true;
-      }
+    NativeModules.KCKeepAwake.activate();
   }
 
   static deactivate() {
-      if (KeepAwake.isActive) {
-          NativeModules.KCKeepAwake.deactivate();
-          KeepAwake.isActive = false;      
-      }
+    NativeModules.KCKeepAwake.deactivate();
   }
 
   componentWillMount() {

--- a/ios/KCKeepAwake.h
+++ b/ios/KCKeepAwake.h
@@ -1,4 +1,4 @@
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface KCKeepAwake : NSObject <RCTBridgeModule>
 @end


### PR DESCRIPTION
This fixes this issue https://github.com/corbt/react-native-keep-awake/issues/15

Let me explain whole use case.
Lets say you activate keepAwake from a button and then the screen stays on as expected. But if you put the app to background and start some other app which takes a lot of memory the operating system might destroy our app's activity. And since we are setting `FLAG_KEEP_SCREEN_ON` to an activity the flag will be removed when activity is killed. This is normal behaviour of Android operating system when it tries to save memory.

Next I though to my self that the solution is activate keepAwake from JS when coming back from background to foreground. I implemented code like this to do that: 
```javascript
import {AppState} from 'react-native';
import store from './src/redux/store';
import KeepAwake from 'react-native-keep-awake';

AppState.addEventListener('change', newAppState => {
  if (newAppState === 'active' && store.getState().isUserOnline) {
    KeepAwake.activate();
  }
});
```
As you can see from the code in my use case I wanted to keep screen on when the user is in online mode. So far logic was flawless but for some reason even though I called `KeepAwake.activate();` the screen did not stay open.

In the end problem lies with `isActive` which is inside of KeepAwake class. It is totally useless at this point. Since there are no drawbacks in calling the native methods `activate` and `deactivate` multiple times in a row. Since they don't crash or anything.

I think the reason why `isActive` was added was because Android would crash because there weren't any null checks for activity. Fix for null check was merged here https://github.com/corbt/react-native-keep-awake/pull/8. The pr which adds `isActive` https://github.com/corbt/react-native-keep-awake/pull/4 which was done 2 months EARLIER. So the JS check is useless now.


Please tell me if you need more explanation :)