### PR TITLE
Fix formatting in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ react-native link
 4. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
 
 	```groovy
-  compile project(':react-native-keep-awake')
-  ```
+  	compile project(':react-native-keep-awake')
+  	```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ react-native link
 
 3. Append the following lines to `android/settings.gradle`:
 
-	```groovy
-	include ':react-native-keep-awake'
+```groovy
+include ':react-native-keep-awake'
 	project(':react-native-keep-awake').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-keep-awake/android')
-	```
+```
 
 4. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
 
-	```groovy
-  	compile project(':react-native-keep-awake')
-  	```
+```groovy
+compile project(':react-native-keep-awake')
+```
 
 ## Usage
 


### PR DESCRIPTION
The formatting is gone haywire in the readme file. I've added a couple of spaces to make the example easy to read again.