### PR TITLE
Update build tools to 25.0.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,8 +11,8 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
This PR addresses https://github.com/corbt/react-native-keep-awake/issues/29. I don't know if anything else is necessary to fix it or if this is a proper fix, but since I use Mobile Center for releases and I can't patch it up locally I need this issue to be addressed.