### PR TITLE
Remove createJSModules @override - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/corbt/keepawake/KCKeepAwakePackage.java
+++ b/android/src/main/java/com/corbt/keepawake/KCKeepAwakePackage.java
@@ -20,7 +20,7 @@ public class KCKeepAwakePackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Fixes #31. This is backwards compatible.