### PR TITLE
iOS backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 This React Native package allows you to prevent the screen from going to sleep while your app is active. It's useful for things like navigation or video playback, where the user expects the app to remain visible over long periods without touch interaction.
 
-## Compatible Versions
-
-**Note:** Due to a breaking change in React Native [0.40](https://github.com/facebook/react-native/releases/tag/v0.40.0), versions 2.0+ of this library is only compatible with RN >=0.40. For older versions of React Native, you'll need to install version 1.07.
-
 ## Installation
 
 As the first step, install this module:

--- a/ios/KCKeepAwake.h
+++ b/ios/KCKeepAwake.h
@@ -1,4 +1,10 @@
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#elif __has_include("RCTBridgeModule.h")
+#import "RCTBridgeModule.h"
+#else
+#import "React/RCTBridgeModule.h"
+#endif
 
 @interface KCKeepAwake : NSObject <RCTBridgeModule>
 @end


### PR DESCRIPTION
This removes the requirement for RN versions < 0.40 to use the `1.x` release.

The problem with compatibility is the import headers in `KCKeepAwake.h`, which can be conditionally included depending on which version of RN the consumer of the library is using.

Prior art can be found in numerous React Native packages, but I'll point to an example in the [react-native-create-library](https://github.com/frostney/react-native-create-library), https://github.com/frostney/react-native-create-library/commit/8ba9086be85dcc400c17fa9ee956e07bcf3bc06c.

If this is approved, I'll update the README as part of this PR