### PR TITLE
readme: Specify package name in link command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install --save react-native-keep-awake
 The plugin can be installed using [react-native link](https://facebook.github.io/react-native/docs/linking-libraries-ios.html) on both iOS and Android. Once installed with npm, just run:
 
 ```
-react-native link
+react-native link react-native-keep-awake
 ```
 
 ### Manual install


### PR DESCRIPTION
Calling react-native link without specifying a package name runs the linking process for all project packages with native modules--some packages incorrectly link twice which can be painful to revert when all we need to do is just link react-native-keep-awake.