### PR TITLE
Implement instance counter and support multiple KeepAwake components

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@
 import React, { Component } from 'react';
 import { NativeModules } from 'react-native';
 
+let mounted = 0;
+
 export default class KeepAwake extends Component<void, void> {
   static activate() {
     NativeModules.KCKeepAwake.activate();
@@ -13,11 +15,15 @@ export default class KeepAwake extends Component<void, void> {
   }
 
   componentWillMount() {
+    mounted++;
     KeepAwake.activate();
   }
 
   componentWillUnmount() {
-    KeepAwake.deactivate();
+    mounted--;
+    if (!mounted) {
+      KeepAwake.deactivate();
+    }
   }
 
   render() {

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ export default class KeepAwake extends Component<void, void> {
     NativeModules.KCKeepAwake.deactivate();
   }
 
-  componentWillMount() {
+  componentDidMount() {
     mounted++;
     KeepAwake.activate();
   }


### PR DESCRIPTION
This adds an instance counter for the KeepAwake component. This fixes that you can add two `<KeepAwake />` instances in your view hierarchy and the look was not removed, if only one (parent) view was removed.