### PR TITLE
Remove deprecated @Override statements to make compatible with RN 0.53

### DIFF
--- a/android/src/main/java/com/corbt/keepawake/KCKeepAwakePackage.java
+++ b/android/src/main/java/com/corbt/keepawake/KCKeepAwakePackage.java
@@ -13,7 +13,6 @@ import java.util.*;
 
 public class KCKeepAwakePackage implements ReactPackage {
 
-    @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
         modules.add(new KCKeepAwake(reactContext));
@@ -25,7 +24,6 @@ public class KCKeepAwakePackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return new ArrayList<>();
     }


### PR DESCRIPTION
Was unable to build in Android Studio after upgrading to RN 0.53. This fixed the issue. 