### PR TITLE
Update build.gradle for RN 0.57

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,18 @@ This React Native package allows you to prevent the screen from going to sleep w
 
 As the first step, install this module:
 
+### React Native 0.57+
+
 ```
 npm install --save react-native-keep-awake
+```
+
+### React Native 0.56 and below
+
+v4 of this module targets gradle 3 syntax, which is not available by default for React Native v0.56 and below. If you are targeting an older version of React Native, stick to v3 of this module:
+
+```
+npm install --save react-native-keep-awake@3
 ```
 
 ### RNPM

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,16 +1,11 @@
 buildscript {
     repositories {
         google()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
         jcenter()
-
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.4'
     }
 }
 
@@ -41,5 +36,5 @@ android {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    compile "com.facebook.react:react-native:${_reactNativeVersion}"
+    implementation "com.facebook.react:react-native:${_reactNativeVersion}"
 }


### PR DESCRIPTION
React Native 0.57 will [scaffold new projects using Gradle 3, instead of Gradle 2](https://github.com/facebook/react-native/commit/6eac2d4e2f5f697043b495002872bfac3e8595cb).

Users who install this library with Gradle 3 will see the following error:

```
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
```

This PR fixes this warning.

Please note: this will cause any users who are still on Gradle 2 to see an error:

```
> Could not find method implementation() for arguments [com.facebook.react:react-native:+] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.
```

This is because `implementation` is only available for users of Gradle 3.

It may therefore be worth bumping the major version of this lib to indicate a breaking change for some users.