### PR TITLE
change buildscript repo order

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
-        jcenter()
         maven {
             url 'https://maven.google.com/'
             name 'Google'
         }
+        jcenter()
+
     }
 
     dependencies {


### PR DESCRIPTION
i'm switching the repository order since https://jcenter.bintray.com/com/android/tools/external/com-intellij/intellij-core/26.0.1/intellij-core-26.0.1.jar can't be found in that repository, which is making Android builds fail.

Related information:
https://stackoverflow.com/questions/52946371/android-studio-could-not-find-intellij-core-jar
https://github.com/gradle/gradle/issues/1120