### PR TITLE
Add google() build dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        google()
         maven {
             url 'https://maven.google.com/'
             name 'Google'


### PR DESCRIPTION
This fixes the following error:

```
[android] FAILURE: Build failed with an exception.
[android] 
[android] * What went wrong:
[android] A problem occurred configuring project ':react-native-keep-awake'.
[android] > Could not resolve all artifacts for configuration ':react-native-keep-awake:classpath'.
[android]    > Could not find intellij-core.jar (com.android.tools.external.com-intellij:intellij-core:26.0.1).
[android]      Searched in the following locations:
[android]          https://jcenter.bintray.com/com/android/tools/external/com-intellij/intellij-core/26.0.1/intellij-core-26.0.1.jar
```